### PR TITLE
Use 1-indexed month number in migration names

### DIFF
--- a/bin/commands/cmd_create.ml
+++ b/bin/commands/cmd_create.ml
@@ -10,7 +10,7 @@ let run ~dir ~name =
     Printf.sprintf
       "%d%02d%02d%02d%02d%02d"
       (1900 + tm.Unix.tm_year)
-      tm.Unix.tm_mon
+      (1 + tm.Unix.tm_mon)
       tm.Unix.tm_mday
       tm.Unix.tm_hour
       tm.Unix.tm_min


### PR DESCRIPTION
The month numbers `tm_mon` are
[0-indexed](https://ocaml.org/api/Unix.html#TYPEtm), but we use these numbers
in the migration file names. This can be confusing to the users.

The current commit changes the month numbers to be "human readable" by
switching to 1-indexed month numbers.