### PR TITLE
Apply required migrations

### DIFF
--- a/bin/commands/cmd_down.ml
+++ b/bin/commands/cmd_down.ml
@@ -1,6 +1,7 @@
 (* open Omigrate *)
 
-let run ~source ~database = Omigrate.down ~source ~database |> Lwt_main.run
+let run ~force ~source ~database =
+  Omigrate.down ~force ~source ~database () |> Lwt_main.run
 
 (* Command line interface *)
 
@@ -25,7 +26,8 @@ let term =
   let open Common.Let_syntax in
   let+ _term = Common.term
   and+ source = Common.source_arg
-  and+ database = Common.database_arg in
-  run ~source ~database |> Common.handle_errors
+  and+ database = Common.database_arg
+  and+ force = Common.force_arg in
+  run ~force ~source ~database |> Common.handle_errors
 
 let cmd = Cmd.v info term

--- a/bin/commands/cmd_setup.ml
+++ b/bin/commands/cmd_setup.ml
@@ -1,8 +1,8 @@
-let run ~source ~database =
+let run ~force ~source ~database =
   let open Lwt_result.Syntax in
   let lwt =
     let* () = Omigrate.create ~database in
-    Omigrate.up ~source ~database
+    Omigrate.up ~force ~source ~database ()
   in
   Lwt_main.run lwt
 
@@ -29,7 +29,8 @@ let term =
   let open Common.Let_syntax in
   let+ _term = Common.term
   and+ source = Common.source_arg
-  and+ database = Common.database_arg in
-  run ~source ~database |> Common.handle_errors
+  and+ database = Common.database_arg
+  and+ force = Common.force_arg in
+  run ~force ~source ~database |> Common.handle_errors
 
 let cmd = Cmd.v info term

--- a/bin/commands/cmd_up.ml
+++ b/bin/commands/cmd_up.ml
@@ -1,6 +1,7 @@
 (* open Omigrate *)
 
-let run ~source ~database = Omigrate.up ~source ~database |> Lwt_main.run
+let run ~force ~source ~database =
+  Omigrate.up ~force ~source ~database () |> Lwt_main.run
 
 (* Command line interface *)
 
@@ -25,7 +26,8 @@ let term =
   let open Common.Let_syntax in
   let+ _term = Common.term
   and+ source = Common.source_arg
-  and+ database = Common.database_arg in
-  run ~source ~database |> Common.handle_errors
+  and+ database = Common.database_arg
+  and+ force = Common.force_arg in
+  run ~force ~source ~database |> Common.handle_errors
 
 let cmd = Cmd.v info term

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -26,6 +26,13 @@ let database_arg =
     & opt (some string) None
     & info [ "database"; "d" ] ~docv:"DATABASE" ~doc ~env)
 
+let force_arg =
+  let doc =
+    "Force the action without worrying about the version in the migration \
+     table."
+  in
+  Arg.(value & flag & info [ "force"; "f" ] ~doc)
+
 let envs = []
 
 let term =

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -2,6 +2,7 @@ val term : int Cmdliner.Term.t
 val handle_errors : (unit, Omigrate.Error.t) Result.t -> int
 val database_arg : string Cmdliner.Term.t
 val source_arg : string Cmdliner.Term.t
+val force_arg : bool Cmdliner.Term.t
 val envs : Cmdliner.Cmd.Env.info list
 val exits : Cmdliner.Cmd.Exit.info list
 


### PR DESCRIPTION
This PR updates the code only to execute the migrations that are not already applied. It provides a new flag `force` to apply all the migrations to ensure we can keep the old behaviour.

The comparison is made this way:

|            |    Compare result          | Bound (aka `force` case)                                                                                                       |
| -------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
| Up      | $version > origin \Leftrightarrow version - origin > 0$    | 0 : $\forall version \in \mathbb{N}^{+}, version - 0 > 0 \Leftrightarrow True $                        |
| Down | $version <= origin \Leftrightarrow version - origin <= 0$  |  maxint : $\forall version \in \mathbb{N}^{+}, version - maxint <= 0 \Leftrightarrow True $|

> **Warning**
> This introduces a breaking change in the API. Maybe the release will need an upgrade in the `Minor` version. 

It requires #3 to be merged before merging.