### PR TITLE
Allow listing drivers available

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Support driver listing (#8, @maiste)
+
 # 0.3.0 - 2022-10-11
 
 - Support partial migrations (#4, @maiste)

--- a/lib/omigrate/driver.ml
+++ b/lib/omigrate/driver.ml
@@ -69,3 +69,4 @@ let load_from_uri s =
   | Some scheme -> load scheme
 
 let register scheme (module T : S) = Hashtbl.add drivers scheme (module T : S)
+let list () = Hashtbl.to_seq_keys drivers |> List.of_seq

--- a/lib/omigrate/omigrate.ml
+++ b/lib/omigrate/omigrate.ml
@@ -112,5 +112,6 @@ module Driver : sig
   val load : string -> ((module Driver.S), Error.t) Result.t
   val load_from_uri : string -> ((module Driver.S), Error.t) Result.t
   val register : string -> (module Driver.S) -> unit
+  val list : unit -> string list
 end =
   Driver


### PR DESCRIPTION
It can be beneficial for users to list drivers available in the current scope. This is what this function intends to add.