### PR TITLE
Make the move to `omigrate.0.3.0` from `0.1.0` easier

### DIFF
--- a/lib/omigrate_drivers/postgres.ml
+++ b/lib/omigrate_drivers/postgres.ml
@@ -138,7 +138,7 @@ module T = struct
           Pgx_lwt_unix.execute conn
             ("SELECT version, dirty FROM "
             ^ quote_statement migrations_table
-            ^ " LIMIT 1;")
+            ^ "ORDER BY version DESC LIMIT 1;")
         in
         match result with
         | [ [ version; dirty ] ] ->

--- a/lib/omigrate_drivers/sqlite_3.ml
+++ b/lib/omigrate_drivers/sqlite_3.ml
@@ -228,7 +228,9 @@ module T = struct
     let t = Db.create ~mode:`NO_CREATE database in
     let stmt =
       Sqlite3.prepare t.Db.db
-        ("SELECT version, dirty FROM " ^ quote_statement migrations_table)
+        ("SELECT version, dirty FROM "
+        ^ quote_statement migrations_table
+        ^ "ORDER BY version DESC LIMIT 1;")
     in
     match Db.query t stmt [] with
     | [ [ version; dirty ] ] ->


### PR DESCRIPTION
Following the #9 discussion, it appears that the behaviour is different between the two versions as one stacks the version, whereas the other truncates the table (`0.3.0`). As `omigrate.0.3.0` tries to fetch one result, it can get a random line from the old schema (with multiple entries). To avoid we need to get the last version in the database. This is the best we can do to simplify this transition.

The idea is to keep the old version schema until a new migration is created and truncate the table. However, it won't affect the operation if no new migration is applied. 

Note that it still requires an action from the user to add the `dirty` column with the following SQL command:
```sql
ALTER TABLE schema_migrations ADD dirty boolean NOT NULL DEFAULT false;
```

We need to release this ASAP so people can make the transition quickly :+1: 

Fixes #9 