### PR TITLE
OCaml-5 support

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -32,7 +32,7 @@
   logs
   fmt
   ; Postgres Driver
-  pgx
+  (pgx (>= 2.2))
   pgx_lwt_unix
   ; Sqlite3 Driver
   (sqlite3 (>= 5.0.1))))

--- a/omigrate.opam
+++ b/omigrate.opam
@@ -17,7 +17,7 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "logs"
   "fmt"
-  "pgx"
+  "pgx" {>= "2.2"}
   "pgx_lwt_unix"
   "sqlite3" {>= "5.0.1"}
   "odoc" {with-doc}


### PR DESCRIPTION
This PR makes the support to `ocaml-5` available by using the right `pgx` version.